### PR TITLE
Add option to use a pure environment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,12 +41,18 @@ jobs:
           fi
           echo "${{ steps.vars.outputs.TEST_HOST_PACKAGE }} is available outside of nix shell"
 
+      - name: Set a test variable
+        run:
+          echo "TEST_ENV_KEEP=kept-var" >> $GITHUB_ENV
+
       - name: Switch into Nix Shell
         uses: ./
         with:
           nix_args: ''
           install_nix: 'true'
           pure_env: "${{ matrix.pure_env == 'pure' && 'true' || 'false' }}"
+          env_keep: 'TEST_ENV_KEEP'
+          bin_keep: '/usr/bin/docker'
 
       - name: Verify Environment Variables
         run: |
@@ -80,3 +86,27 @@ jobs:
             exit 1
           fi
           echo "${{ steps.vars.outputs.TEST_HOST_PACKAGE }} is ${{ matrix.pure_env == 'pure' && 'not ' || '' }}available in the nix shell"
+
+      - name: GITHUB_ variables should still be set
+        run: |
+          if [[ $GITHUB_ACTIONS != 'true' ]]; then
+            echo "GITHUB_ variables should still be set"
+            exit 1
+          fi
+          echo "GITHUB_ variables are still set"
+
+      - name: Variables specified in env_keep should still be set
+        run: |
+          if [[ $TEST_ENV_KEEP != 'kept-var' ]]; then
+            echo "TEST_ENV_KEEP should still be set"
+            exit 1
+          fi
+          echo "TEST_ENV_KEEP is still set"
+
+      - name: Binaries specified in bin_keep should still be available
+        run: |
+          if ! command -v docker; then
+            echo "docker should still be available"
+            exit 1
+          fi
+          echo "docker is still available"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,19 +6,45 @@ on:
       - main
   pull_request:
 
+env:
+  TEST_NIX_PACKAGE: 'hello'
+  TEST_HOST_PACKAGE: 'perl'
+
 jobs:
   test-action:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        pure_env:
+          - 'pure'
+          - 'impure'
 
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+
+      - name: Test that ${{ env.TEST_NIX_PACKAGE }} is not available outside of nix shell
+        run: |
+          if command -v ${{ env.TEST_NIX_PACKAGE }}; then
+            echo "'${{ env.TEST_NIX_PACKAGE }}' command should not be available outside of nix shell"
+            exit 1
+          fi
+          echo "'${{ env.TEST_NIX_PACKAGE }}' command is not available outside of nix shell"
+
+      - name: ${{ env.TEST_HOST_PACKAGE }} should be available outside of nix shell
+        run: |
+          if ! command -v ${{ env.TEST_HOST_PACKAGE }}; then
+            echo "${{ env.TEST_HOST_PACKAGE }} should be available outside of nix shell"
+            exit 1
+          fi
+          echo "${{ env.TEST_HOST_PACKAGE }} is available outside of nix shell"
 
       - name: Switch into Nix Shell
         uses: ./
         with:
           nix_args: ''
           install_nix: 'true'
+          pure_env: "${{ matrix.pure_env == 'pure' && 'true' || 'false' }}"
 
       - name: Verify Environment Variables
         run: |
@@ -36,11 +62,19 @@ jobs:
 
       - name: Test Nix Package Availability
         run: |
-          echo "Checking if 'hello' command is available..."
-          if ! command -v hello >/dev/null; then
-            echo "'hello' command is not available"
+          echo "Checking if ${{ env.TEST_NIX_PACKAGE }} command is available..."
+          if ! command -v ${{ env.TEST_NIX_PACKAGE }}; then
+            echo "'${{ env.TEST_NIX_PACKAGE }}' command is not available"
             exit 1
           fi
-          echo "'hello' command is available"
+          echo "'${{ env.TEST_NIX_PACKAGE }}' command is available"
           echo "Running 'hello' command:"
-          hello
+          ${{ env.TEST_NIX_PACKAGE }}
+
+      - name: ${{ env.TEST_HOST_PACKAGE }} should ${{ matrix.pure_env == 'pure' && 'not ' || '' }}be available in the nix shell
+        run: |
+          if ${{ matrix.pure_env == 'impure' && '!' || ''}} command -v ${{ env.TEST_HOST_PACKAGE }}; then
+            echo "${{ env.TEST_HOST_PACKAGE }} should ${{ matrix.pure_env == 'pure' && 'not ' || '' }}be available in the nix shell"
+            exit 1
+          fi
+          echo "${{ env.TEST_HOST_PACKAGE }} is ${{ matrix.pure_env == 'pure' && 'not ' || '' }}available in the nix shell"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,10 +6,6 @@ on:
       - main
   pull_request:
 
-env:
-  TEST_NIX_PACKAGE: 'hello'
-  TEST_HOST_PACKAGE: 'perl'
-
 jobs:
   test-action:
     runs-on: ubuntu-latest
@@ -20,24 +16,30 @@ jobs:
           - 'impure'
 
     steps:
+      - name: Set workflow variables
+        id: vars
+        run: |
+          echo "TEST_NIX_PACKAGE=hello" >> $GITHUB_OUTPUT
+          echo "TEST_HOST_PACKAGE=perl" >> $GITHUB_OUTPUT
+
       - name: Checkout Repository
         uses: actions/checkout@v4
 
-      - name: Test that ${{ env.TEST_NIX_PACKAGE }} is not available outside of nix shell
+      - name: Test that ${{ steps.vars.outputs.TEST_NIX_PACKAGE }} is not available outside of nix shell
         run: |
-          if command -v ${{ env.TEST_NIX_PACKAGE }}; then
-            echo "'${{ env.TEST_NIX_PACKAGE }}' command should not be available outside of nix shell"
+          if command -v ${{ steps.vars.outputs.TEST_NIX_PACKAGE }}; then
+            echo "'${{ steps.vars.outputs.TEST_NIX_PACKAGE }}' command should not be available outside of nix shell"
             exit 1
           fi
-          echo "'${{ env.TEST_NIX_PACKAGE }}' command is not available outside of nix shell"
+          echo "'${{ steps.vars.outputs.TEST_NIX_PACKAGE }}' command is not available outside of nix shell"
 
-      - name: ${{ env.TEST_HOST_PACKAGE }} should be available outside of nix shell
+      - name: ${{ steps.vars.outputs.TEST_HOST_PACKAGE }} should be available outside of nix shell
         run: |
-          if ! command -v ${{ env.TEST_HOST_PACKAGE }}; then
-            echo "${{ env.TEST_HOST_PACKAGE }} should be available outside of nix shell"
+          if ! command -v ${{ steps.vars.outputs.TEST_HOST_PACKAGE }}; then
+            echo "${{ steps.vars.outputs.TEST_HOST_PACKAGE }} should be available outside of nix shell"
             exit 1
           fi
-          echo "${{ env.TEST_HOST_PACKAGE }} is available outside of nix shell"
+          echo "${{ steps.vars.outputs.TEST_HOST_PACKAGE }} is available outside of nix shell"
 
       - name: Switch into Nix Shell
         uses: ./
@@ -62,19 +64,19 @@ jobs:
 
       - name: Test Nix Package Availability
         run: |
-          echo "Checking if ${{ env.TEST_NIX_PACKAGE }} command is available..."
-          if ! command -v ${{ env.TEST_NIX_PACKAGE }}; then
-            echo "'${{ env.TEST_NIX_PACKAGE }}' command is not available"
+          echo "Checking if ${{ steps.vars.outputs.TEST_NIX_PACKAGE }} command is available..."
+          if ! command -v ${{ steps.vars.outputs.TEST_NIX_PACKAGE }}; then
+            echo "'${{ steps.vars.outputs.TEST_NIX_PACKAGE }}' command is not available"
             exit 1
           fi
-          echo "'${{ env.TEST_NIX_PACKAGE }}' command is available"
+          echo "'${{ steps.vars.outputs.TEST_NIX_PACKAGE }}' command is available"
           echo "Running 'hello' command:"
-          ${{ env.TEST_NIX_PACKAGE }}
+          ${{ steps.vars.outputs.TEST_NIX_PACKAGE }}
 
-      - name: ${{ env.TEST_HOST_PACKAGE }} should ${{ matrix.pure_env == 'pure' && 'not ' || '' }}be available in the nix shell
+      - name: ${{ steps.vars.outputs.TEST_HOST_PACKAGE }} should ${{ matrix.pure_env == 'pure' && 'not ' || '' }}be available in the nix shell
         run: |
-          if ${{ matrix.pure_env == 'impure' && '!' || ''}} command -v ${{ env.TEST_HOST_PACKAGE }}; then
-            echo "${{ env.TEST_HOST_PACKAGE }} should ${{ matrix.pure_env == 'pure' && 'not ' || '' }}be available in the nix shell"
+          if ${{ matrix.pure_env == 'impure' && '!' || ''}} command -v ${{ steps.vars.outputs.TEST_HOST_PACKAGE }}; then
+            echo "${{ steps.vars.outputs.TEST_HOST_PACKAGE }} should ${{ matrix.pure_env == 'pure' && 'not ' || '' }}be available in the nix shell"
             exit 1
           fi
-          echo "${{ env.TEST_HOST_PACKAGE }} is ${{ matrix.pure_env == 'pure' && 'not ' || '' }}available in the nix shell"
+          echo "${{ steps.vars.outputs.TEST_HOST_PACKAGE }} is ${{ matrix.pure_env == 'pure' && 'not ' || '' }}available in the nix shell"

--- a/action.yml
+++ b/action.yml
@@ -26,46 +26,42 @@ runs:
       run: |
         set -e
 
-        # Function to save environment variables to a file
-        action_sed="$(which sed)"
-        action_sort="$(which sort)"
-        action_save_env() {
-          compgen -e | while read -r var; do
-            value="${!var}"
-            # Replace newlines with \n for comparison
-            escaped_value=$(printf '%s' "$value" | $action_sed ':a;N;$!ba;s/\n/\\n/g')
-            echo "${var}=${escaped_value}"
-          done | $action_sort > "$1"
-        }
-
+        action_save_env=$(mktemp)
         action_before_env=$(mktemp)
         action_after_env=$(mktemp)
         action_diff_env=$(mktemp)
 
+        cat - <<EOF >"$action_save_env"
+          #!/usr/bin/env bash
+          env | grep -E "^[a-zA-Z_][a-zA-Z0-9_]+=" | cut -d= -f1 | while read -r var; do
+            value="\${!var}"
+            # Replace newlines with \n for comparison
+            escaped_value=\$(printf '%s' "\$value" | "$(which sed)" ':a;N;\$!ba;s/\\n/\\\\n/g')
+            echo "\${var}=\${escaped_value}"
+          done | "$(which sort)" > "\$1"
+        EOF
+        chmod +x $action_save_env
+
         # Save initial environment
-        action_save_env "$action_before_env"
+        "$action_save_env" "$action_before_env"
+        echo -e "\nOriginal environment variables"
+        cat "$action_before_env"
+        echo ""
 
-        # Load Nix environment
-        action_nix_dev_env_script=$(mktemp)
-        nix print-dev-env ${{ inputs.nix_args }} > "$action_nix_dev_env_script"
-         if [[ '${{ inputs.pure_env }}' == 'true' ]]; then
-          compgen -e | grep -v '^action_' | while read -r var; do
-            echo "Unsetting $var"
-            unset "$var"
-          done
-        fi
-        source "$action_nix_dev_env_script"
-
-        # Save environment after loading Nix
-        action_save_env "$action_after_env"
+        # Save environment after loading Nix shell
+        nix develop ${{ inputs.nix_args }} ${{ inputs.pure_env == 'true' && '--ignore-environment' || '' }} --command "$action_save_env" "$action_after_env"
+        echo -e "\nNix environment variables"
+        cat "$action_after_env"
+        echo ""
 
         # Unset changed variables from GITHUB_ENV
-        diff "$action_before_env" "$action_after_env" | grep '^<' | sed -E 's/< ([^=]+).*/\1=""/' | tee -a "$GITHUB_ENV" || true
+        diff "$action_before_env" "$action_after_env" | grep '^<' | sed -E 's/< ([^=]+).*/\1=""/' >> "$GITHUB_ENV" || true
 
         # Find differences
-        diff "$action_before_env" "$action_after_env" | grep '^>' | sed 's/^> //' | tee "$action_diff_env" || true
+        diff "$action_before_env" "$action_after_env" | grep '^>' | sed 's/^> //' > "$action_diff_env" || true
 
         # Add changed variables to GITHUB_ENV
+        echo -e "\nSetting variables"
         while IFS='=' read -r name value; do
           echo "$name=$value"
 
@@ -76,6 +72,7 @@ runs:
           echo "$unescaped_value" >> "$GITHUB_ENV"
           echo "EOF" >> "$GITHUB_ENV"
         done < "$action_diff_env"
+
 
 branding:
   icon: 'terminal'

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: 'Whether to install Nix. Set to false if Nix is already installed.'
     required: false
     default: 'true'
+  pure_env:
+    description: 'Whether to use a pure nix environment.'
+    required: false
+    default: 'false'
 runs:
   using: 'composite'
   steps:
@@ -23,32 +27,39 @@ runs:
         set -xe
 
         # Function to save environment variables to a file
-        save_env() {
+        action_sed="$(which sed)"
+        action_sort="$(which sort)"
+        action_save_env() {
           compgen -e | while read -r var; do
             value="${!var}"
             # Replace newlines with \n for comparison
-            escaped_value=$(printf '%s' "$value" | sed ':a;N;$!ba;s/\n/\\n/g')
+            escaped_value=$(printf '%s' "$value" | $action_sed ':a;N;$!ba;s/\n/\\n/g')
             echo "${var}=${escaped_value}"
-          done | sort > "$1"
+          done | $action_sort > "$1"
         }
 
-        before_env=$(mktemp)
-        after_env=$(mktemp)
-        diff_env=$(mktemp)
+        action_before_env=$(mktemp)
+        action_after_env=$(mktemp)
+        action_diff_env=$(mktemp)
 
         # Save initial environment
-        save_env "$before_env"
+        action_save_env "$action_before_env"
 
         # Load Nix environment
-        nix_dev_env_script=$(mktemp)
-        nix print-dev-env ${{ inputs.nix_args }} > "$nix_dev_env_script"
-        source "$nix_dev_env_script"
+        action_nix_dev_env_script=$(mktemp)
+        nix print-dev-env ${{ inputs.nix_args }} > "$action_nix_dev_env_script"
+         if [[ '${{ inputs.pure_env }}' == 'true' ]]; then
+          compgen -e | grep -v '^action_' | while read -r var; do
+            unset "$var"
+          done
+        fi
+        source "$action_nix_dev_env_script"
 
         # Save environment after loading Nix
-        save_env "$after_env"
+        action_save_env "$action_after_env"
 
         # Find differences
-        diff "$before_env" "$after_env" | grep '^>' | sed 's/^> //' > "$diff_env" || true
+        diff "$action_before_env" "$action_after_env" | grep '^>' | sed 's/^> //' > "$action_diff_env" || true
 
         # Add changed variables to GITHUB_ENV
         while IFS='=' read -r name value; do
@@ -58,10 +69,10 @@ runs:
           echo "${name}<<EOF" >> "$GITHUB_ENV"
           echo "$unescaped_value" >> "$GITHUB_ENV"
           echo "EOF" >> "$GITHUB_ENV"
-        done < "$diff_env"
+        done < "$action_diff_env"
 
         echo "Environment variables added to GITHUB_ENV:"
-        cat "$diff_env"
+        cat "$action_diff_env"
 
 branding:
   icon: 'terminal'

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ runs:
     - name: Switch into Nix Shell
       shell: bash
       run: |
-        set -xe
+        set -e
 
         # Function to save environment variables to a file
         action_sed="$(which sed)"
@@ -50,6 +50,7 @@ runs:
         nix print-dev-env ${{ inputs.nix_args }} > "$action_nix_dev_env_script"
          if [[ '${{ inputs.pure_env }}' == 'true' ]]; then
           compgen -e | grep -v '^action_' | while read -r var; do
+            echo "Unsetting $var"
             unset "$var"
           done
         fi
@@ -58,11 +59,16 @@ runs:
         # Save environment after loading Nix
         action_save_env "$action_after_env"
 
+        # Unset changed variables from GITHUB_ENV
+        diff "$action_before_env" "$action_after_env" | grep '^<' | sed -E 's/< ([^=]+).*/\1=""/' | tee -a "$GITHUB_ENV" || true
+
         # Find differences
-        diff "$action_before_env" "$action_after_env" | grep '^>' | sed 's/^> //' > "$action_diff_env" || true
+        diff "$action_before_env" "$action_after_env" | grep '^>' | sed 's/^> //' | tee "$action_diff_env" || true
 
         # Add changed variables to GITHUB_ENV
         while IFS='=' read -r name value; do
+          echo "$name=$value"
+
           # Unescape newlines
           unescaped_value=$(printf '%s' "$value" | sed 's/\\n/\n/g')
 
@@ -70,9 +76,6 @@ runs:
           echo "$unescaped_value" >> "$GITHUB_ENV"
           echo "EOF" >> "$GITHUB_ENV"
         done < "$action_diff_env"
-
-        echo "Environment variables added to GITHUB_ENV:"
-        cat "$action_diff_env"
 
 branding:
   icon: 'terminal'

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,15 @@ inputs:
     description: 'Whether to use a pure nix environment.'
     required: false
     default: 'false'
+  env_keep:
+    description: 'Environment variables to keep in the pure nix shell (in addition to the GITHUB_ and RUNNER_ variables). Space separated'
+    required: false
+    default: ''
+  bin_keep:
+    description: "Individual binaries or directories to be kept in the pure nix shell's path. Space separated"
+    required: false
+    default: ''
+
 runs:
   using: 'composite'
   steps:
@@ -73,6 +82,24 @@ runs:
           echo "EOF" >> "$GITHUB_ENV"
         done < "$action_diff_env"
 
+        # Keep environment variables
+        for var in CI $(compgen -e | grep -E '^GITHUB_') $(compgen -e | grep -E '^RUNNER_') ${{ inputs.env_keep }}; do
+          echo "${var}<<EOF" >> "$GITHUB_ENV"
+          echo "${!var}" >> "$GITHUB_ENV"
+          echo "EOF" >> "$GITHUB_ENV"
+        done
+
+        # Keep binaries
+        action_bin_path="$(mktemp -d)"
+        for path in ${{ inputs.bin_keep }} "$action_bin_path"; do
+          if [ -d "$path" ]; then
+            echo "Adding directory $path to PATH"
+            sed -i -E "/PATH<<EOF/{n;s|^|$path:|}" "$GITHUB_ENV"
+          elif [ -f "$path" ]; then
+            echo "Adding file $path to PATH"
+            ln -s "$path" "$action_bin_path/"
+          fi
+        done
 
 branding:
   icon: 'terminal'


### PR DESCRIPTION
This adds a new input `pure_env` to the action that, if enabled, clears the environment before activating the nix shell, thus making sure that no programs installed on the host leak into the nix environment